### PR TITLE
Hotfix 1.5.2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
           java-version: 1.8
           settings-path: ${{ github.workspace }}
 
+      - name: Load local Maven repository cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.5.2
+-----
+
+**Added**
+
+**Fixed**
+
+* CVE-2021-45046
+
+**Dependencies**
+
+* ``org.apache.logging.log4j:log4j-core:2.15.0`` -> ``2.16.0``
+* ``org.apache.logging.log4j:log4j-api:2.15.0`` -> ``2.16.0``
+
+**Deprecated**
+
+
 1.5.1
 -----
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,13 @@
 		<version>1.4.0</version>
 	</parent>
 	<artifactId>barcode-dragon-portlet</artifactId>
-	<version>1.5.1</version>
+	<version>1.5.2</version>
 	<name>Barcode Dragon Portlet</name>
 	<url>https://github.com/qbicsoftware/barcode-dragon-portlet</url>
 	<description>Portlet which allows the creation of printable sample sheets with barcodes for customers.</description>
 	<packaging>war</packaging>
 	<properties>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.16.0</log4j.version>
 	</properties>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->


### PR DESCRIPTION
1.5.2
-----

**Added**

**Fixed**

* CVE-2021-45046

**Dependencies**

* ``org.apache.logging.log4j:log4j-core:2.15.0`` -> ``2.16.0``
* ``org.apache.logging.log4j:log4j-api:2.15.0`` -> ``2.16.0``

**Deprecated**

